### PR TITLE
fix intrusive InventoryListener

### DIFF
--- a/src/main/java/at/noahb/invsee/InvseePlugin.java
+++ b/src/main/java/at/noahb/invsee/InvseePlugin.java
@@ -43,7 +43,9 @@ public final class InvseePlugin extends JavaPlugin {
             getLogger().warning("LuckPerms not found. Some features might not work.");
         }
 
-        getServer().getPluginManager().addPermission(new Permission(Constants.LOOKUP_UNSEEN_PERMISSION));
+        if (getServer().getPluginManager().getPermission(Constants.LOOKUP_UNSEEN_PERMISSION) == null) {
+            getServer().getPluginManager().addPermission(new Permission(Constants.LOOKUP_UNSEEN_PERMISSION));
+        }
     }
 
     private void registerCommands() {

--- a/src/main/java/at/noahb/invsee/common/listener/InventoryListener.java
+++ b/src/main/java/at/noahb/invsee/common/listener/InventoryListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 public record InventoryListener(InvseePlugin instance) implements Listener {
@@ -26,6 +27,9 @@ public record InventoryListener(InvseePlugin instance) implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+        if (!isSession(event.getInventory())) {
+            return;
+        }
         boolean setEmpty = false;
 
         if (event.getClickedInventory() != null && event.getClickedInventory().getSize() == 45 && event.getSlot() > 41) {
@@ -91,5 +95,9 @@ public record InventoryListener(InvseePlugin instance) implements Listener {
         }
         player.getScheduler().run(this.instance, scheduledTask -> this.instance.getInvseeSessionManager().updateContent(player), null);
         player.getScheduler().run(this.instance, scheduledTask -> this.instance.getEnderseeSessionManager().updateContent(player), null);
+    }
+
+    public boolean isSession(Inventory inv) {
+        return instance.getInvseeSessionManager().isSessionInventory(inv) || instance.getEnderseeSessionManager().isSessionInventory(inv);
     }
 }

--- a/src/main/java/at/noahb/invsee/common/session/SessionManager.java
+++ b/src/main/java/at/noahb/invsee/common/session/SessionManager.java
@@ -5,6 +5,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -69,6 +70,11 @@ public abstract class SessionManager {
         return sessions.stream()
                 .filter(session -> session.hasSubscriber(subscriber))
                 .findFirst();
+    }
+
+    public boolean isSessionInventory(Inventory inventory) {
+        return sessions.stream()
+                .anyMatch(session -> session.getInventory().equals(inventory));
     }
 
     protected abstract Session createSession(OfflinePlayer offlinePlayer, UUID subscriber);


### PR DESCRIPTION
This listener in its current state listens to **all** inventories that are sized `45`. This fixes that by ensuring the inventory is in at least one of the session managers before performing any operations